### PR TITLE
Abort deploy if client build failed

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
   "main": "webpack.config.js",
   "scripts": {
     "start": "webpack-dev-server --progress --colors",
-    "build": "webpack --mode=build"
+    "build": "webpack --mode=build --bail"
   },
   "babel": {
     "presets": [

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -80,11 +80,7 @@ namespace :deploy do
         with build_prerelease: fetch(:build_prerelease), build_release: fetch(:build_release), public_host: fetch(:public_host) do
           execute :ls, "-l"
           execute :npm, 'install'
-          build_res = capture :npm, 'run build'
-          puts build_res
-          if build_res.include?('Cannot resolve module')
-            abort 'Couldn\'t build the client'
-          end
+          execute :npm, 'run build'
         end
       end
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -80,7 +80,11 @@ namespace :deploy do
         with build_prerelease: fetch(:build_prerelease), build_release: fetch(:build_release), public_host: fetch(:public_host) do
           execute :ls, "-l"
           execute :npm, 'install'
-          execute :npm, 'run build'
+          build_res = capture :npm, 'run build'
+          puts build_res
+          if build_res.include?('Cannot resolve module')
+            abort 'Couldn\'t build the client'
+          end
         end
       end
     end


### PR DESCRIPTION
https://trello.com/c/vfbpj57F/404-capistrano-break-the-build-if-unable-to-build-the-frontend