### PR TITLE
Rename references to Plus to active charge

### DIFF
--- a/client/app/actions/ExtendedUserActions.js
+++ b/client/app/actions/ExtendedUserActions.js
@@ -13,7 +13,6 @@ export default class ExtendedUserActions {
     )
   }
 
-  // Boilerplate example: getting a user and setting them
   getCurrent(token) {
     this.setShopifyUserFetchFailed(false)
     return ExtendedUserSource.fetchCurrent(token).then(resp => {
@@ -24,9 +23,8 @@ export default class ExtendedUserActions {
   }
 
   // Boilerplate example: setting other properties on a user
-  upgradeToPlus(currentUser) {
-    Analytics.track('Upgraded to Plus')
-    currentUser.plus = true // reflect what has happened on the server without refreshing the whole user
+  activateCharge(currentUser) {
+    currentUser.activeCharge = true // reflect what has happened on the server without refreshing the whole user
     UserActions.setExtendedUser(currentUser)
     return true
   }

--- a/client/app/containers/ChargeContainer.js
+++ b/client/app/containers/ChargeContainer.js
@@ -38,7 +38,7 @@ export default class ChargeContainer extends React.Component {
         ),
         actionButtonLabel: 'Go to .......'
       })
-      ExtendedUserActions.upgradeToPlus(this.context.currentUser)
+      ExtendedUserActions.activateCharge(this.context.currentUser)
     } else if (this.state.event === 'failed') {
       this.setState({
         title: 'Upgrade failed',


### PR DESCRIPTION
Track 'Charge Activated' event on the server instead of 'Upgraded to Plus' on the client

Fixed https://github.com/pemberton-rank/react-shopify-app/issues/24